### PR TITLE
投稿削除機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
 
 ### Association
 - has_many :comments, dependent: :destroy
-- has_many :likes
+- has_many :likes, dependent: :destroy
 - has_many :liked_users, through: :likes, source: :user
 - belongs_to :user
 

--- a/app/assets/stylesheets/modules/_flash.scss
+++ b/app/assets/stylesheets/modules/_flash.scss
@@ -16,6 +16,6 @@
     font-size: 20px;
     font-weight: bold;
     text-align: center;
-    background-color: red;
+    background-color: #ff7a8f;
   }
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
-  before_action :set_post, only: [:show, :edit, :update]
-  before_action :login_required, only: [:new, :create, :edit, :update]
-  before_action :ensure_correct_user, only: [:edit, :update]
+  before_action :set_post, only: [:show, :edit, :update, :destroy]
+  before_action :login_required, except: [:index, :show]
+  before_action :ensure_correct_user, only: [:edit, :update, :destroy]
 
   def index
     @posts = Post.includes(:user).order('created_at DESC')
@@ -38,6 +38,14 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    if @post.destroy 
+      redirect_to root_path, notice: "投稿の削除が完了しました"
+    else
+      redirect_to root_path, notice: "権限がありません"
+    end
+  end
+
   private
 
   def post_params
@@ -50,13 +58,13 @@ class PostsController < ApplicationController
 
   def login_required
     unless user_signed_in?
-      redirect_to root_path, notice: "ログインしてください"
+      redirect_to root_path, alert: "ログインしてください"
     end
   end
 
   def ensure_correct_user
     if @post.user_id != current_user.id
-      redirect_to root_path, notice: '権限がありません'
+      redirect_to root_path, alert: '権限がありません'
     end
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -42,7 +42,7 @@ class PostsController < ApplicationController
     if @post.destroy 
       redirect_to root_path, notice: "投稿の削除が完了しました"
     else
-      redirect_to root_path, notice: "権限がありません"
+      redirect_to root_path, alert: "権限がありません"
     end
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -25,7 +25,7 @@ class ProfilesController < ApplicationController
 
   def ensure_correct_user
     if @profile.user_id != current_user.id
-      redirect_to root_path, notice: '権限がありません'
+      redirect_to root_path, alert: '権限がありません'
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
-  has_many :likes
+  has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
 
   validates :content, presence: true

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -8,7 +8,7 @@
             = link_to edit_post_path(@post), class: "Post-btn__link" do
               %p.Post-btn__text 編集
           .Post-btn
-            = link_to "#", class: "Post-btn__link" do
+            = link_to post_path(@post), method: :delete, data: {confirm: "削除しますか"}, class: "Post-btn__link" do
               %p.Post-btn__text 削除
       .Post-prof
         .Post-prof__name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   root "home#index"
   resources :users, only: :show
   resources :profiles, only: [:edit, :update]
-  resources :posts, only: [:index, :new, :create, :show, :edit, :update] do
+  resources :posts do
     resources :comments, only: :create
     resources :likes, only: [:create, :destroy]
   end


### PR DESCRIPTION
# What
投稿の削除機能を実装する
* postsコントローラーのdestroyアクションを作成する。
* 投稿を削除すると同時に、コメント・いいねも削除する。
* destroyのリンクは投稿者しか踏めないようにする、URLを直接入力して投稿者以外が削除できないようにする。

# Why
投稿内容を削除したい場合に必要な機能であるため。