### PR TITLE
コメント削除機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/_comment.scss
+++ b/app/assets/stylesheets/modules/_comment.scss
@@ -86,6 +86,12 @@
           width: 85%;
           color: #424b54;
         }
+
+        &__delete {
+          a {
+            color: #00b05e;
+          }
+        }
       }
     }
   }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,6 +8,15 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    comment = Comment.find_by(id: params[:id], post_id: params[:post_id])
+    if comment.destroy 
+      redirect_to post_path(comment.post_id)
+    else
+      redirect_to root_path, alert: "権限がありません"
+    end
+  end
+
   private
 
   def comment_params

--- a/app/views/posts/_comment_form.html.haml
+++ b/app/views/posts/_comment_form.html.haml
@@ -28,3 +28,7 @@
               = link_to comment.user.profile.nickname, "/users/#{comment.user_id}"
             %p.Comment-item__text
               = comment.content
+            - if user_signed_in? && current_user.id == comment.user_id
+              %p.Comment-item__delete
+                = link_to post_comment_path(comment.post.id, comment.id), method: :delete do
+                  = icon('fas', 'times')

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -2,7 +2,7 @@
 .post-show-wrapper
   .post-holder
     .Post-item
-      - if current_user.id == @post.user_id
+      - if user_signed_in? && current_user.id == @post.user_id
         .post-btn-list
           .Post-btn
             = link_to edit_post_path(@post), class: "Post-btn__link" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   resources :users, only: :show
   resources :profiles, only: [:edit, :update]
   resources :posts do
-    resources :comments, only: :create
+    resources :comments, only: [:create, :destroy]
     resources :likes, only: [:create, :destroy]
   end
 end


### PR DESCRIPTION
# What
コメントの削除機能を実装する。
* commentsコントローラーのdestroyアクションを作成する。
* destroyのリンクはコメント作成者しか踏めないようにする。

# Why
コメントを削除できるようにすることでユーザーにとって利便性が向上するため。