### PR TITLE
ユーザー情報編集機能の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,4 +7,16 @@ class UsersController < ApplicationController
 
   def edit
   end
+
+  def update
+    if current_user.update(user_params)
+      redirect_to root_path, notice: "ユーザー情報を更新しました"
+    else
+      render :edit
+    end
+  end
+
+  def user_params
+    params.require(:user).permit(:last_name, :first_name, :last_name_kana, :first_name_kana, :email, :password)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :ensure_correct_user, only: [:edit, :update]
+
   def show
     @user = User.find(params[:id])
     @posts = @user.posts.order('created_at DESC')
@@ -16,7 +18,15 @@ class UsersController < ApplicationController
     end
   end
 
+private
+
   def user_params
     params.require(:user).permit(:last_name, :first_name, :last_name_kana, :first_name_kana, :email, :password)
+  end
+
+  def ensure_correct_user
+    if current_user.id != params[:id].to_i
+      redirect_to root_path, alert: '権限がありません'
+    end
   end
 end

--- a/app/views/home/_header.html.haml
+++ b/app/views/home/_header.html.haml
@@ -11,6 +11,9 @@
           = link_to "マイページ", user_path(current_user.id)
         %p
           = link_to "ログアウト", destroy_user_session_path, method: :delete
+        %p
+          = link_to edit_user_path(current_user) do
+            = icon('fas', 'cog')
       - else
         %p
           = link_to "新規登録", new_user_registration_path

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,52 @@
+.User
+  %h1
+    =link_to "relief", root_path
+    
+  .User__wrapper
+    %h2.User__title ユーザー情報編集
+    = form_with model: current_user, local: true do |f|
+      - if current_user.errors.any?
+        .profile-errors
+          %ul
+            - current_user.errors.full_messages.each do |user|
+              %li= user
+      
+      .Name-form
+        .Name-form__wrapper
+          %ul.Name-form__field
+            %li 名字
+            %li.Name-form__required 必須
+          = f.text_field :last_name, class: "Name-form__input"
+        .Name-form__wrapper
+          %ul.Name-form__field
+            %li 名前
+            %li.Name-form__required 必須
+          = f.text_field :first_name, class: "Name-form__input"
+
+      .Name-form
+        .Name-form__wrapper
+          %ul.Name-form__field
+            %li 名字(かな)
+            %li.Name-form__required 必須
+          = f.text_field :last_name_kana, class: "Name-form__input"
+        .Name-form__wrapper
+          %ul.Name-form__field
+            %li 名前(かな)
+            %li.Name-form__required 必須
+          = f.text_field :first_name_kana, class: "Name-form__input"
+
+      .User-form
+        %ul.User-form__field
+          %li メールアドレス
+          %li.User-form__required 必須
+        = f.email_field :email, autofocus: true, autocomplete: "email", class: "User-form__input"
+
+      .User-form
+        %ul.User-form__field
+          %li パスワード
+          %li.User-form__required 必須
+        = f.password_field :password, autocomplete: "new-password", placeholder: '6文字以上', class: "User-form__input"
+
+      .Information
+        .Information__submit
+          = f.submit "登録する", class: "Information__submit--btn"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     post 'profiles', to: 'users/registrations#create_profile'
   end
   root "home#index"
-  resources :users, only: :show
+  resources :users, only: [:show, :edit, :update]
   resources :profiles, only: [:edit, :update]
   resources :posts do
     resources :comments, only: [:create, :destroy]


### PR DESCRIPTION
# What
ユーザー情報の編集機能を実装する。

* usersコントローラーのedit・updateアクションを作成する。
* editのリンクはユーザー本人しか踏めないようにする。
* URLを直接入力して本人以外がeditに飛べないようにする。

# Why
メールアドレスやパスワードを変更するために必要な機能であるため。
